### PR TITLE
chore: restrict git add/commit commands in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,7 +29,9 @@
       "Bash(git add -A:*)",
       "Bash(git add --all:*)",
       "Bash(git commit -a:*)",
-      "Bash(git commit --all:*)"
+      "Bash(git commit --all:*)",
+      "Bash(git commit -am:*)",
+      "Bash(git commit -all:*)"
     ]
   }
 }


### PR DESCRIPTION
Prevent Claude from running broad git add/commit commands that could accidentally commit unintended changes.

Adds restrictions to `.claude/settings.json` for:
- `git add .`
- `git add -A`
- `git add --all`
- `git commit -a`
- `git commit --all`