### PR TITLE
fix: resolve TypeScript type errors in Chrome API usage

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -823,7 +823,7 @@ function waitForTabLoad(tabId: number, timeoutMs: number = 30000): Promise<void>
 
     const listener = (
       updatedTabId: number,
-      changeInfo: chrome.tabs.TabChangeInfo
+      changeInfo: { status?: string }
     ) => {
       if (updatedTabId === tabId && changeInfo.status === "complete") {
         if (!resolved) {
@@ -966,7 +966,7 @@ async function handleListTabGroups(): Promise<{
     id: number;
     windowId: number;
     title: string;
-    color: chrome.tabGroups.ColorEnum;
+    color: string;
     collapsed: boolean;
   }>;
 }> {

--- a/src/lib/provider-registry.ts
+++ b/src/lib/provider-registry.ts
@@ -962,7 +962,8 @@ function getCachedModels<T>(cacheKey: string): Promise<CachedModels<T> | null> {
       if (chrome.runtime.lastError) {
         reject(chrome.runtime.lastError);
       } else {
-        resolve(result[cacheKey] || null);
+        const cached = result[cacheKey] as CachedModels<T> | undefined;
+        resolve(cached || null);
       }
     });
   });

--- a/src/sidepanel/controllers.ts
+++ b/src/sidepanel/controllers.ts
@@ -574,6 +574,15 @@ async function init(): Promise<void> {
   await checkPendingAction();
 }
 
+interface PendingAction {
+  type: string;
+  payload: {
+    tabId?: number;
+    linkUrl?: string;
+    links?: string[];
+  };
+}
+
 async function checkPendingAction(): Promise<void> {
   try {
     const result = await chrome.storage.session.get("pendingAction");
@@ -581,7 +590,7 @@ async function checkPendingAction(): Promise<void> {
       // Clear the pending action first to prevent duplicate processing
       await chrome.storage.session.remove("pendingAction");
 
-      const { type, payload } = result.pendingAction;
+      const { type, payload } = result.pendingAction as PendingAction;
       if (type === "CREATE_NOTEBOOK_AND_ADD_PAGE" && payload.tabId) {
         handleCreateNotebookAndAddPage(payload.tabId);
       } else if (type === "CREATE_NOTEBOOK_AND_ADD_LINK" && payload.linkUrl) {


### PR DESCRIPTION
## Summary
- Fix `chrome.tabs.TabChangeInfo` type error by using inline type definition
- Fix `chrome.tabGroups.ColorEnum` type error by using `string` type
- Fix `CachedModels` type assertion in provider-registry storage retrieval
- Add `PendingAction` interface for session storage data typing

## Test plan
- [x] Run `npm run build` - passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)