### PR TITLE
feat(chat): make sources list collapsible and anchor chat input to bottom

### DIFF
--- a/src/sidepanel/components/ChatTab.tsx
+++ b/src/sidepanel/components/ChatTab.tsx
@@ -42,30 +42,46 @@ export function ChatTab(props: ChatTabProps) {
         </div>
       </details>
 
-      <div className="sources-header">
-        <h3 className="section-title">
-          Active Sources (
-          <span id="source-count">0</span>
-          )
-          <a href="#" id="manage-sources" className="link">Manage</a>
-        </h3>
-        <button id="refresh-all-sources-btn" className="btn btn-small btn-outline" title="Refresh all sources">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M23 4v6h-6"></path>
-            <path d="M1 20v-6h6"></path>
-            <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
-          </svg>
-        </button>
-      </div>
-      <div id="active-sources" className="sources-list compact"></div>
-
-      <button id="add-page-btn" className="btn btn-outline btn-small">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-          <line x1="12" y1="5" x2="12" y2="19"></line>
-          <line x1="5" y1="12" x2="19" y2="12"></line>
-        </svg>
-        Add Current Page
-      </button>
+      {/* Sources Section (Collapsible) */}
+      <details id="sources-section" className="sources-section" open>
+        <summary className="sources-section-header">
+          <h3 className="section-title">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+              <line x1="16" y1="13" x2="8" y2="13"></line>
+              <line x1="16" y1="17" x2="8" y2="17"></line>
+              <polyline points="10 9 9 9 8 9"></polyline>
+            </svg>
+            Active Sources (
+            <span id="source-count">0</span>
+            )
+          </h3>
+          <div className="sources-section-actions">
+            <a href="#" id="manage-sources" className="link">Manage</a>
+            <button id="refresh-all-sources-btn" className="btn btn-small btn-outline" title="Refresh all sources">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M23 4v6h-6"></path>
+                <path d="M1 20v-6h6"></path>
+                <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
+              </svg>
+            </button>
+            <svg className="sources-section-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </div>
+        </summary>
+        <div className="sources-section-content">
+          <div id="active-sources" className="sources-list compact"></div>
+          <button id="add-page-btn" className="btn btn-outline btn-small">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="12" y1="5" x2="12" y2="19"></line>
+              <line x1="5" y1="12" x2="19" y2="12"></line>
+            </svg>
+            Add Current Page
+          </button>
+        </div>
+      </details>
 
       {/* Suggested Links Section (Collapsible) */}
       <details id="suggested-links-section" className="suggested-links-section" style={{ display: 'none' }}>

--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -1314,21 +1314,6 @@ input[type="text"]:focus {
   }
 }
 
-.sources-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.sources-header .section-title {
-  margin-bottom: 0;
-}
-
-.sources-header .btn-small {
-  padding: 4px 8px;
-}
-
 #refresh-all-sources-btn {
   display: flex;
   align-items: center;
@@ -1503,6 +1488,80 @@ details.summary-section[open] .summary-chevron {
 .summary-actions {
   display: flex;
   gap: 4px;
+}
+
+/* ============================================================================
+   Sources Section (Collapsible)
+   ============================================================================ */
+
+details.sources-section {
+  margin-top: 16px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+}
+
+details.sources-section > summary {
+  padding: 12px 16px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+details.sources-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.sources-section[open] > summary {
+  border-bottom: 1px solid var(--border-muted);
+}
+
+.sources-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.sources-section-header .section-title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sources-section-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sources-section-chevron {
+  transition: transform 0.2s ease;
+  color: var(--text-secondary);
+}
+
+details.sources-section[open] .sources-section-chevron {
+  transform: rotate(180deg);
+}
+
+.sources-section .section-title {
+  margin-top: 0;
+  margin-bottom: 0;
+  color: var(--text-primary);
+}
+
+.sources-section-content {
+  padding: 12px;
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.sources-section-content .sources-list.compact {
+  margin-bottom: 12px;
+}
+
+.sources-section-content #add-page-btn {
+  margin-bottom: 0;
 }
 
 /* ============================================================================
@@ -2630,6 +2689,25 @@ details.suggested-links-section[open] .suggested-links-chevron {
 
 #tab-chat #add-page-btn {
   margin-bottom: 0;
+}
+
+/* Sticky query box at bottom of chat tab */
+#tab-chat .query-box {
+  position: sticky;
+  bottom: 0;
+  margin-top: 16px;
+  background: var(--bg-primary);
+  z-index: 10;
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+}
+
+#tab-chat .helper-text {
+  position: sticky;
+  bottom: -24px;
+  background: var(--bg-primary);
+  padding-bottom: 8px;
+  margin-bottom: 0;
+  z-index: 10;
 }
 
 .chat-header {


### PR DESCRIPTION
- Convert sources section to collapsible <details> element matching the
  existing Overview and Suggested Links patterns
- Add chevron indicator that rotates on expand/collapse
- Include document icon in the collapsible header
- Make the query-box sticky at the bottom of the chat tab for quick access
- Add subtle shadow to sticky query-box for visual separation
- Clean up unused .sources-header CSS rules