### PR TITLE
ci: update Node.js to v22 for semantic-release compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -94,7 +94,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Fix CI failure by updating Node.js from v20 to v22.

## Problem
semantic-release 25.0.2 requires Node.js ^22.14.0 || >= 24.10.0, but the CI workflow was using Node.js 20, causing this error:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.6.
```

## Solution
Update all CI jobs to use Node.js 22 instead of 20.

## Changes
- Updated `node-version` from `'20'` to `'22'` in all CI jobs (lint, build, test, test-e2e, release)

See: https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md