### PR TITLE
ci: add caching for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Cache Puppeteer Chrome
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/puppeteer
+          key: ${{ runner.os }}-puppeteer-chrome-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-puppeteer-chrome-
+
+      - name: Cache Vitest E2E
+        uses: actions/cache@v4
+        with:
+          path: .vitest
+          key: ${{ runner.os }}-vitest-e2e-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-vitest-e2e-
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ extension.pem
 *.crx
 .worktrees/
 tests/.chrome-profile/
+.vitest/

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  // Cache directory for CI and local
+  cache: {
+    dir: '.vitest',
+  },
   test: {
     // E2E test configuration
     testTimeout: 30000,


### PR DESCRIPTION
Adds caching for Puppeteer Chrome binaries (~170MB) and Vitest test results to reduce CI runtime by ~30-60s per workflow.

**Changes:**
- Cache `~/.cache/puppeteer` with key based on `package-lock.json`
- Cache `.vitest` directory for test results
- Add `.vitest/` to `.gitignore`