### PR TITLE
Fix chat panel up arrow color contrast

### DIFF
--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -698,6 +698,10 @@ h3 {
   flex-shrink: 0;
 }
 
+.query-box .icon-btn.btn-primary svg {
+  color: inherit;
+}
+
 .query-box input {
   flex: 1;
   border: none;


### PR DESCRIPTION
The up arrow SVG in the chat query button was inheriting the wrong color from `.query-box svg` (--text-muted) instead of the button's white text color. Added a specific rule to ensure the button's SVG inherits the correct color from its parent.