### PR TITLE
feat: respect user's light/dark theme preference in transform content

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -984,6 +984,7 @@ async function getModel(): Promise<LanguageModel | null> {
 - [x] **Hooks-based architecture** (Preact hooks for state management)
 - [x] **Service layer** (business logic separated from UI)
 - [x] Side panel UI with light/dark theme support (user preference)
+- [x] Transform content respects user's theme preference (sidepanel and fullscreen views)
 - [x] Bottom tab navigation (Add, Chat, Transform, Library, Settings)
 - [x] IndexedDB storage with StorageAdapter
 - [x] Notebook CRUD operations

--- a/src/lib/sandbox-renderer.ts
+++ b/src/lib/sandbox-renderer.ts
@@ -24,6 +24,7 @@ type SandboxMessage
   = | RenderContentMessage
     | RenderInteractiveMessage
     | ClearContentMessage
+    | SetThemeMessage
     | SandboxReadyMessage
     | RenderCompleteMessage
     | HeightResponseMessage
@@ -43,6 +44,11 @@ interface RenderInteractiveMessage {
 
 interface ClearContentMessage {
   type: 'CLEAR_CONTENT'
+}
+
+interface SetThemeMessage {
+  type: 'SET_THEME'
+  theme: 'light' | 'dark' | null
 }
 
 interface SandboxReadyMessage {
@@ -293,6 +299,19 @@ export class SandboxRenderer {
     if (this.iframe?.contentWindow) {
       this.iframe.contentWindow.postMessage({ type: 'CLEAR_CONTENT' }, '*')
       this.iframe.style.height = '20px'
+    }
+  }
+
+  /**
+   * Set the theme in the sandbox
+   * @param theme - 'light', 'dark', or null for system preference
+   */
+  setTheme(theme: 'light' | 'dark' | null): void {
+    if (this.iframe?.contentWindow) {
+      this.iframe.contentWindow.postMessage({
+        type: 'SET_THEME',
+        theme,
+      } satisfies SetThemeMessage, '*')
     }
   }
 

--- a/src/lib/sandbox-renderer.unit.test.ts
+++ b/src/lib/sandbox-renderer.unit.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for SandboxRenderer setTheme method
+ *
+ * Tests the theme management functionality including:
+ * - setTheme: Sends theme to sandbox via postMessage
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+
+// Mock chrome.runtime.getURL
+vi.stubGlobal('chrome', {
+  runtime: {
+    getURL: vi.fn((path: string) => `chrome-extension://test-id/${path}`),
+  },
+})
+
+describe('SandboxRenderer', () => {
+  let mockPostMessage: ReturnType<typeof vi.fn>
+  let mockIframe: HTMLIFrameElement
+  let mockContainer: HTMLElement
+  let originalCreateElement: typeof document.createElement
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Create mock postMessage
+    mockPostMessage = vi.fn()
+
+    // Save original createElement
+    originalCreateElement = document.createElement.bind(document)
+
+    // Create mock iframe with contentWindow using original createElement
+    mockIframe = originalCreateElement('iframe')
+    Object.defineProperty(mockIframe, 'contentWindow', {
+      value: {
+        postMessage: mockPostMessage,
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    // Mock sandbox property with add method
+    Object.defineProperty(mockIframe, 'sandbox', {
+      value: {
+        add: vi.fn(),
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    // Create mock container
+    mockContainer = originalCreateElement('div')
+
+    // Mock document.createElement to return our mock iframe
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'iframe') {
+        return mockIframe
+      }
+      return originalCreateElement(tagName)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('setTheme', () => {
+    it('sends SET_THEME message with light theme', async () => {
+      const { SandboxRenderer } = await import('./sandbox-renderer')
+      const renderer = new SandboxRenderer(mockContainer)
+
+      renderer.setTheme('light')
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        { type: 'SET_THEME', theme: 'light' },
+        '*',
+      )
+    })
+
+    it('sends SET_THEME message with dark theme', async () => {
+      const { SandboxRenderer } = await import('./sandbox-renderer')
+      const renderer = new SandboxRenderer(mockContainer)
+
+      renderer.setTheme('dark')
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        { type: 'SET_THEME', theme: 'dark' },
+        '*',
+      )
+    })
+
+    it('sends SET_THEME message with null for system preference', async () => {
+      const { SandboxRenderer } = await import('./sandbox-renderer')
+      const renderer = new SandboxRenderer(mockContainer)
+
+      renderer.setTheme(null)
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        { type: 'SET_THEME', theme: null },
+        '*',
+      )
+    })
+
+    it('does not throw when iframe contentWindow is null', async () => {
+      const { SandboxRenderer } = await import('./sandbox-renderer')
+      const renderer = new SandboxRenderer(mockContainer)
+
+      // Simulate iframe being destroyed
+      Object.defineProperty(mockIframe, 'contentWindow', {
+        value: null,
+        writable: true,
+      })
+
+      // Should not throw
+      expect(() => renderer.setTheme('light')).not.toThrow()
+    })
+
+    it('can be called multiple times with different themes', async () => {
+      const { SandboxRenderer } = await import('./sandbox-renderer')
+      const renderer = new SandboxRenderer(mockContainer)
+
+      renderer.setTheme('light')
+      renderer.setTheme('dark')
+      renderer.setTheme(null)
+
+      expect(mockPostMessage).toHaveBeenCalledTimes(3)
+      expect(mockPostMessage).toHaveBeenNthCalledWith(1, { type: 'SET_THEME', theme: 'light' }, '*')
+      expect(mockPostMessage).toHaveBeenNthCalledWith(2, { type: 'SET_THEME', theme: 'dark' }, '*')
+      expect(mockPostMessage).toHaveBeenNthCalledWith(3, { type: 'SET_THEME', theme: null }, '*')
+    })
+  })
+})

--- a/src/sandbox/fullscreen-sandbox.html
+++ b/src/sandbox/fullscreen-sandbox.html
@@ -27,6 +27,7 @@
       min-height: 0;
     }
 
+    /* Light theme (default) */
     iframe {
       display: block;
       width: 100%;
@@ -40,6 +41,18 @@
       color: #ef4444;
       text-align: center;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+
+    /* Dark theme (explicit) */
+    html[data-theme="dark"] iframe {
+      background: #1e1e2e;
+    }
+
+    /* System preference fallback */
+    @media (prefers-color-scheme: dark) {
+      html:not([data-theme]) iframe {
+        background: #1e1e2e;
+      }
     }
   </style>
 </head>

--- a/src/sandbox/fullscreen-sandbox.ts
+++ b/src/sandbox/fullscreen-sandbox.ts
@@ -95,16 +95,17 @@ function renderContent(content: string, isInteractive: boolean, theme?: 'light' 
 
 function wrapContent(html: string, isInteractive: boolean, theme?: 'light' | 'dark' | null): string {
   const trimmed = html.trim()
-  const hasDoctype = trimmed.toLowerCase().startsWith('<!doctype')
-  const hasHtml = trimmed.toLowerCase().startsWith('<html')
+  const lowerHtml = trimmed.toLowerCase()
+  const hasDoctype = lowerHtml.startsWith('<!doctype')
+  const hasHtmlTag = lowerHtml.includes('<html')
 
   // Determine data-theme attribute
   const themeAttr = theme ? ` data-theme="${theme}"` : ''
 
-  if (hasDoctype || hasHtml) {
+  if (hasDoctype || hasHtmlTag) {
     // Content is already a full document - inject theme attribute if we can
-    if (theme && hasHtml) {
-      // Try to inject data-theme into existing <html> tag
+    if (theme && hasHtmlTag) {
+      // Try to inject data-theme into existing <html> tag (works with DOCTYPE + html)
       return html.replace(/<html([^>]*)>/i, `<html$1${themeAttr}>`)
     }
     return html
@@ -189,6 +190,17 @@ ${html}
       html:not([data-theme]) th { background: #2a2a2a; }
       html:not([data-theme]) th, html:not([data-theme]) td { border-color: #444; }
       html:not([data-theme]) hr { border-color: #444; }
+    }
+
+    /* Print styles - override dark theme for printing */
+    @media print {
+      body { background: white !important; color: #1a1a1a !important; }
+      pre { background: #f5f5f5 !important; }
+      code { background: #f0f0f0 !important; }
+      blockquote { background: #f8f8ff !important; color: #666 !important; }
+      th { background: #f5f5f5 !important; }
+      th, td { border-color: #ddd !important; }
+      hr { border-color: #ddd !important; }
     }
   </style>
 </head>

--- a/src/sandbox/fullscreen-sandbox.ts
+++ b/src/sandbox/fullscreen-sandbox.ts
@@ -24,6 +24,7 @@ interface SandboxContentMessage {
   title: string
   content: string
   isInteractive: boolean
+  theme?: 'light' | 'dark' | null
 }
 
 interface SandboxReadyMessage {
@@ -57,7 +58,7 @@ function initializePostMessageListener(): void {
     }
 
     // Render content (title is displayed by the wrapper page)
-    renderContent(data.content, data.isInteractive)
+    renderContent(data.content, data.isInteractive, data.theme)
   })
 
   // Signal to parent that we're ready to receive content
@@ -66,7 +67,7 @@ function initializePostMessageListener(): void {
   } satisfies SandboxReadyMessage, '*')
 }
 
-function renderContent(content: string, isInteractive: boolean): void {
+function renderContent(content: string, isInteractive: boolean, theme?: 'light' | 'dark' | null): void {
   const iframe = document.getElementById('content-frame') as HTMLIFrameElement | null
 
   if (!iframe) {
@@ -74,8 +75,17 @@ function renderContent(content: string, isInteractive: boolean): void {
     return
   }
 
+  // Apply theme to this page's root element (for iframe background styling)
+  if (theme === null || theme === undefined) {
+    // System preference - remove attribute to let CSS media queries handle it
+    document.documentElement.removeAttribute('data-theme')
+  }
+  else {
+    document.documentElement.setAttribute('data-theme', theme)
+  }
+
   // Wrap content in a full HTML document if needed
-  const wrappedContent = wrapContent(content, isInteractive)
+  const wrappedContent = wrapContent(content, isInteractive, theme)
 
   // Use srcdoc to load content - this inherits the sandbox page's permissive CSP
   // which allows inline scripts. The sandbox attribute on the iframe provides
@@ -83,13 +93,20 @@ function renderContent(content: string, isInteractive: boolean): void {
   iframe.srcdoc = wrappedContent
 }
 
-function wrapContent(html: string, isInteractive: boolean): string {
+function wrapContent(html: string, isInteractive: boolean, theme?: 'light' | 'dark' | null): string {
   const trimmed = html.trim()
   const hasDoctype = trimmed.toLowerCase().startsWith('<!doctype')
   const hasHtml = trimmed.toLowerCase().startsWith('<html')
 
+  // Determine data-theme attribute
+  const themeAttr = theme ? ` data-theme="${theme}"` : ''
+
   if (hasDoctype || hasHtml) {
-    // Content is already a full document
+    // Content is already a full document - inject theme attribute if we can
+    if (theme && hasHtml) {
+      // Try to inject data-theme into existing <html> tag
+      return html.replace(/<html([^>]*)>/i, `<html$1${themeAttr}>`)
+    }
     return html
   }
 
@@ -98,7 +115,7 @@ function wrapContent(html: string, isInteractive: boolean): string {
   // For non-interactive content, we add basic styling
   if (isInteractive) {
     return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en"${themeAttr}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -110,20 +127,23 @@ ${html}
 </html>`
   }
 
-  // Non-interactive content with styling
+  // Non-interactive content with theme-aware styling
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en"${themeAttr}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html, body { height: 100%; }
+
+    /* Light theme (default) */
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       font-size: 16px;
       line-height: 1.6;
       color: #1a1a1a;
+      background: #ffffff;
       padding: 24px;
       max-width: 800px;
       margin: 0 auto;
@@ -144,6 +164,32 @@ ${html}
     th, td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
     th { background: #f5f5f5; font-weight: 600; }
     hr { border: none; border-top: 1px solid #ddd; margin: 1.5em 0; }
+
+    /* Dark theme (explicit) */
+    html[data-theme="dark"] body {
+      color: #e5e5e5;
+      background: #1e1e2e;
+    }
+    html[data-theme="dark"] pre { background: #2a2a2a; }
+    html[data-theme="dark"] code { background: #333; }
+    html[data-theme="dark"] blockquote { background: #1a1a2e; color: #b0b0b0; }
+    html[data-theme="dark"] th { background: #2a2a2a; }
+    html[data-theme="dark"] th, html[data-theme="dark"] td { border-color: #444; }
+    html[data-theme="dark"] hr { border-color: #444; }
+
+    /* System preference fallback (when no explicit theme set) */
+    @media (prefers-color-scheme: dark) {
+      html:not([data-theme]) body {
+        color: #e5e5e5;
+        background: #1e1e2e;
+      }
+      html:not([data-theme]) pre { background: #2a2a2a; }
+      html:not([data-theme]) code { background: #333; }
+      html:not([data-theme]) blockquote { background: #1a1a2e; color: #b0b0b0; }
+      html:not([data-theme]) th { background: #2a2a2a; }
+      html:not([data-theme]) th, html:not([data-theme]) td { border-color: #444; }
+      html:not([data-theme]) hr { border-color: #444; }
+    }
   </style>
 </head>
 <body>

--- a/src/sandbox/fullscreen-wrapper.html
+++ b/src/sandbox/fullscreen-wrapper.html
@@ -13,34 +13,12 @@
 
     html, body {
       height: 100%;
-      background: #1a1a2e;
     }
 
     body {
       display: flex;
       flex-direction: column;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      color: #e4e4e7;
-    }
-
-    header {
-      padding: 16px 24px;
-      background: #252538;
-      border-bottom: 1px solid #3f3f5a;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    h1 {
-      font-size: 20px;
-      color: #fff;
-      font-weight: 500;
-    }
-
-    .branding {
-      font-size: 12px;
-      color: #9ca3af;
     }
 
     .iframe-container {
@@ -60,13 +38,90 @@
       align-items: center;
       justify-content: center;
       height: 100%;
-      color: #9ca3af;
     }
 
     .error {
       padding: 20px;
       color: #ef4444;
       text-align: center;
+    }
+
+    /* Light theme (default) */
+    body {
+      background: #f9fafb;
+      color: #1f2937;
+    }
+
+    header {
+      padding: 16px 24px;
+      background: #ffffff;
+      border-bottom: 1px solid #e5e7eb;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    h1 {
+      font-size: 20px;
+      color: #111827;
+      font-weight: 500;
+    }
+
+    .branding {
+      font-size: 12px;
+      color: #6b7280;
+    }
+
+    .loading {
+      color: #6b7280;
+    }
+
+    /* Dark theme (explicit) */
+    html[data-theme="dark"] body {
+      background: #1a1a2e;
+      color: #e4e4e7;
+    }
+
+    html[data-theme="dark"] header {
+      background: #252538;
+      border-bottom-color: #3f3f5a;
+    }
+
+    html[data-theme="dark"] h1 {
+      color: #fff;
+    }
+
+    html[data-theme="dark"] .branding {
+      color: #9ca3af;
+    }
+
+    html[data-theme="dark"] .loading {
+      color: #9ca3af;
+    }
+
+    /* System preference fallback (when no explicit theme set) */
+    @media (prefers-color-scheme: dark) {
+      html:not([data-theme]) body {
+        background: #1a1a2e;
+        color: #e4e4e7;
+      }
+
+      html:not([data-theme]) header {
+        background: #252538;
+        border-bottom-color: #3f3f5a;
+      }
+
+      html:not([data-theme]) h1 {
+        color: #fff;
+      }
+
+      html:not([data-theme]) .branding {
+        color: #9ca3af;
+      }
+
+      html:not([data-theme]) .loading {
+        color: #9ca3af;
+      }
     }
   </style>
 </head>

--- a/src/sandbox/fullscreen-wrapper.ts
+++ b/src/sandbox/fullscreen-wrapper.ts
@@ -23,6 +23,7 @@ interface FullscreenContentMessage {
   title: string
   content: string
   isInteractive: boolean
+  theme?: 'light' | 'dark' | null
 }
 
 // Message types for postMessage communication (to/from sandbox iframe)
@@ -35,6 +36,7 @@ interface SandboxContentMessage {
   title: string
   content: string
   isInteractive: boolean
+  theme?: 'light' | 'dark' | null
 }
 
 // Initialize bridge
@@ -103,6 +105,15 @@ function initializeBridge(): void {
     }
     document.title = `${data.title} - FolioLM`
 
+    // Apply theme to wrapper page
+    if (data.theme === null || data.theme === undefined) {
+      // System preference - remove attribute to let CSS media queries handle it
+      document.documentElement.removeAttribute('data-theme')
+    }
+    else {
+      document.documentElement.setAttribute('data-theme', data.theme)
+    }
+
     // Forward to sandbox or store for later
     if (sandboxReady) {
       forwardContentToSandbox(sandboxFrame, data)
@@ -128,5 +139,6 @@ function forwardContentToSandbox(
     title: content.title,
     content: content.content,
     isInteractive: content.isInteractive,
+    theme: content.theme,
   } satisfies SandboxContentMessage, '*')
 }

--- a/src/sandbox/sandbox.html
+++ b/src/sandbox/sandbox.html
@@ -152,43 +152,84 @@
       margin-right: 0.5em;
     }
 
-    /* Dark mode support via CSS custom properties */
+    /* Dark mode support via data-theme attribute (explicit user preference) */
+    html[data-theme="dark"] body {
+      color: #e5e5e5;
+      background: #1e1e2e;
+    }
+
+    html[data-theme="dark"] pre {
+      background: #2a2a2a;
+    }
+
+    html[data-theme="dark"] code {
+      background: #333;
+    }
+
+    html[data-theme="dark"] blockquote {
+      background: #1a1a2e;
+      color: #b0b0b0;
+    }
+
+    html[data-theme="dark"] th {
+      background: #2a2a2a;
+    }
+
+    html[data-theme="dark"] th,
+    html[data-theme="dark"] td {
+      border-color: #444;
+    }
+
+    html[data-theme="dark"] tr:nth-child(even) {
+      background: #1f1f1f;
+    }
+
+    html[data-theme="dark"] tr:hover {
+      background: #2a2a2a;
+    }
+
+    html[data-theme="dark"] hr {
+      border-color: #444;
+    }
+
+    /* Fallback: system preference when no explicit theme is set */
     @media (prefers-color-scheme: dark) {
-      body {
+      html:not([data-theme]) body {
         color: #e5e5e5;
         background: #1e1e2e;
       }
 
-      pre {
+      html:not([data-theme]) pre {
         background: #2a2a2a;
       }
 
-      code {
+      html:not([data-theme]) code {
         background: #333;
       }
 
-      blockquote {
+      html:not([data-theme]) blockquote {
         background: #1a1a2e;
         color: #b0b0b0;
       }
 
-      th {
+      html:not([data-theme]) th {
         background: #2a2a2a;
       }
 
-      th, td {
+      html:not([data-theme]) th,
+      html:not([data-theme]) td {
         border-color: #444;
       }
 
-      tr:nth-child(even) {
+      html:not([data-theme]) tr:nth-child(even) {
         background: #1f1f1f;
       }
 
-      tr:hover {
+      html:not([data-theme]) tr:hover {
         background: #2a2a2a;
       }
 
-      hr {
+      html:not([data-theme]) hr {
         border-color: #444;
       }
     }
@@ -213,12 +254,22 @@
       border-radius: 3px;
     }
 
+    /* Dark mode scrollbar - explicit theme */
+    html[data-theme="dark"] ::-webkit-scrollbar-track {
+      background: #2a2a2a;
+    }
+
+    html[data-theme="dark"] ::-webkit-scrollbar-thumb {
+      background: #444;
+    }
+
+    /* Fallback: system preference when no explicit theme */
     @media (prefers-color-scheme: dark) {
-      ::-webkit-scrollbar-track {
+      html:not([data-theme]) ::-webkit-scrollbar-track {
         background: #2a2a2a;
       }
 
-      ::-webkit-scrollbar-thumb {
+      html:not([data-theme]) ::-webkit-scrollbar-thumb {
         background: #444;
       }
     }

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -22,6 +22,7 @@ type SandboxMessage
     | RenderInteractiveMessage
     | ClearContentMessage
     | GetHeightMessage
+    | SetThemeMessage
     | SandboxReadyMessage
     | RenderCompleteMessage
     | HeightResponseMessage
@@ -46,6 +47,11 @@ interface ClearContentMessage {
 interface GetHeightMessage {
   type: 'GET_HEIGHT'
   messageId: number
+}
+
+interface SetThemeMessage {
+  type: 'SET_THEME'
+  theme: 'light' | 'dark' | null
 }
 
 interface SandboxReadyMessage {
@@ -159,6 +165,17 @@ window.addEventListener('message', (event: MessageEvent) => {
       messageId: msg.messageId,
       height: document.body.scrollHeight,
     } satisfies HeightResponseMessage, '*')
+  }
+  else if (type === 'SET_THEME') {
+    const msg = data as SetThemeMessage
+    // Apply theme to the root HTML element
+    if (msg.theme === null) {
+      // System preference - remove attribute to let CSS media queries handle it
+      document.documentElement.removeAttribute('data-theme')
+    }
+    else {
+      document.documentElement.setAttribute('data-theme', msg.theme)
+    }
   }
 })
 

--- a/src/sidepanel/components/SandboxContent.tsx
+++ b/src/sidepanel/components/SandboxContent.tsx
@@ -8,6 +8,8 @@
 import { useRef, useEffect, useState } from 'preact/hooks'
 import { SandboxRenderer } from '../../lib/sandbox-renderer'
 import { renderMarkdown } from '../../lib/markdown-renderer'
+import { getPreference, onThemeChange } from '../hooks/useTheme'
+import type { ThemePreference } from '../../types/index'
 
 interface SandboxContentProps {
   /** The content to render */
@@ -44,6 +46,14 @@ export function SandboxContent(props: SandboxContentProps) {
     const renderer = new SandboxRenderer(container)
     rendererRef.current = renderer
 
+    // Helper to get the theme value to send to sandbox
+    const getThemeForSandbox = (preference: ThemePreference): 'light' | 'dark' | null => {
+      if (preference === 'system') {
+        return null // Let the sandbox use its CSS media queries
+      }
+      return preference
+    }
+
     // Render content
     const renderContent = async () => {
       setLoading(true)
@@ -51,6 +61,10 @@ export function SandboxContent(props: SandboxContentProps) {
 
       try {
         await renderer.waitForReady()
+
+        // Apply the current theme to the sandbox
+        const currentPreference = getPreference()
+        renderer.setTheme(getThemeForSandbox(currentPreference))
 
         if (isInteractive) {
           // Interactive content (quiz, flashcards, etc.)
@@ -73,8 +87,16 @@ export function SandboxContent(props: SandboxContentProps) {
 
     void renderContent()
 
+    // Subscribe to theme changes to update the sandbox
+    const unsubscribe = onThemeChange((preference) => {
+      if (rendererRef.current) {
+        rendererRef.current.setTheme(getThemeForSandbox(preference))
+      }
+    })
+
     // Cleanup on unmount
     return () => {
+      unsubscribe()
       if (rendererRef.current) {
         rendererRef.current.destroy()
         rendererRef.current = null

--- a/src/sidepanel/hooks/useTransform.ts
+++ b/src/sidepanel/hooks/useTransform.ts
@@ -288,10 +288,15 @@ function generateFullPageHtml(title: string, content: string, theme: 'light' | '
     }
 
     @media print {
-      body { background: white; color: black; }
+      body { background: white !important; color: black !important; }
       .container { max-width: 100%; }
-      .content { background: white; border: 1px solid #ccc; }
-      .content h1, .content h2, .content h3, .content h4 { color: black; }
+      .content { background: white !important; border: 1px solid #ccc !important; }
+      .content h1, .content h2, .content h3, .content h4 { color: black !important; }
+      .content code, .content pre { background: #f3f4f6 !important; }
+      .content th { background: #f9fafb !important; }
+      .content th, .content td { border-color: #e5e7eb !important; }
+      .content blockquote { color: #6b7280 !important; }
+      h1 { color: #111827 !important; border-bottom-color: #e5e7eb !important; }
     }
   </style>
 </head>

--- a/src/sidepanel/hooks/useTransform.ts
+++ b/src/sidepanel/hooks/useTransform.ts
@@ -14,6 +14,7 @@
 import { useCallback, useEffect } from 'preact/hooks'
 import DOMPurify from 'dompurify'
 import type { Source, TransformationType, BackgroundTransform, Message } from '../../types/index.ts'
+import { getPreference } from './useTheme'
 import {
   saveTransformation,
   deleteTransformation,
@@ -113,22 +114,28 @@ export interface UseTransformReturn {
 
 /**
  * Generate a full HTML page for viewing markdown transforms
+ * @param theme - 'light', 'dark', or null for system preference
  */
-function generateFullPageHtml(title: string, content: string): string {
+function generateFullPageHtml(title: string, content: string, theme: 'light' | 'dark' | null): string {
+  // Determine data-theme attribute
+  const themeAttr = theme ? ` data-theme="${theme}"` : ''
+
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="en"${themeAttr}>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>${escapeHtml(title)} - FolioLM</title>
   <style>
     * { box-sizing: border-box; }
+
+    /* Light theme (default) */
     body {
       margin: 0;
       padding: 24px;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: #1a1a2e;
-      color: #e4e4e7;
+      background: #f9fafb;
+      color: #1f2937;
       min-height: 100vh;
       line-height: 1.6;
     }
@@ -139,17 +146,18 @@ function generateFullPageHtml(title: string, content: string): string {
     h1 {
       margin: 0 0 24px 0;
       font-size: 28px;
-      color: #fff;
-      border-bottom: 1px solid #3f3f5a;
+      color: #111827;
+      border-bottom: 1px solid #e5e7eb;
       padding-bottom: 12px;
     }
     .content {
-      background: #252538;
+      background: #ffffff;
       border-radius: 12px;
       padding: 32px;
+      border: 1px solid #e5e7eb;
     }
     .content h1, .content h2, .content h3, .content h4 {
-      color: #fff;
+      color: #111827;
       margin-top: 24px;
       margin-bottom: 12px;
     }
@@ -167,13 +175,13 @@ function generateFullPageHtml(title: string, content: string): string {
       margin-bottom: 8px;
     }
     .content code {
-      background: #1a1a2e;
+      background: #f3f4f6;
       padding: 2px 6px;
       border-radius: 4px;
       font-family: 'SF Mono', Monaco, 'Courier New', monospace;
     }
     .content pre {
-      background: #1a1a2e;
+      background: #f3f4f6;
       padding: 16px;
       border-radius: 8px;
       overflow-x: auto;
@@ -186,7 +194,7 @@ function generateFullPageHtml(title: string, content: string): string {
       border-left: 3px solid #8b5cf6;
       margin: 0 0 16px 0;
       padding-left: 16px;
-      color: #a1a1aa;
+      color: #6b7280;
     }
     .content table {
       width: 100%;
@@ -194,16 +202,91 @@ function generateFullPageHtml(title: string, content: string): string {
       margin: 16px 0;
     }
     .content th, .content td {
-      border: 1px solid #3f3f5a;
+      border: 1px solid #e5e7eb;
       padding: 12px;
       text-align: left;
     }
     .content th {
-      background: #1a1a2e;
+      background: #f9fafb;
     }
     .content a {
       color: #8b5cf6;
     }
+
+    /* Dark theme (explicit) */
+    html[data-theme="dark"] body {
+      background: #1a1a2e;
+      color: #e4e4e7;
+    }
+    html[data-theme="dark"] h1 {
+      color: #fff;
+      border-bottom-color: #3f3f5a;
+    }
+    html[data-theme="dark"] .content {
+      background: #252538;
+      border-color: #3f3f5a;
+    }
+    html[data-theme="dark"] .content h1,
+    html[data-theme="dark"] .content h2,
+    html[data-theme="dark"] .content h3,
+    html[data-theme="dark"] .content h4 {
+      color: #fff;
+    }
+    html[data-theme="dark"] .content code {
+      background: #1a1a2e;
+    }
+    html[data-theme="dark"] .content pre {
+      background: #1a1a2e;
+    }
+    html[data-theme="dark"] .content blockquote {
+      color: #a1a1aa;
+    }
+    html[data-theme="dark"] .content th,
+    html[data-theme="dark"] .content td {
+      border-color: #3f3f5a;
+    }
+    html[data-theme="dark"] .content th {
+      background: #1a1a2e;
+    }
+
+    /* System preference fallback (when no explicit theme set) */
+    @media (prefers-color-scheme: dark) {
+      html:not([data-theme]) body {
+        background: #1a1a2e;
+        color: #e4e4e7;
+      }
+      html:not([data-theme]) h1 {
+        color: #fff;
+        border-bottom-color: #3f3f5a;
+      }
+      html:not([data-theme]) .content {
+        background: #252538;
+        border-color: #3f3f5a;
+      }
+      html:not([data-theme]) .content h1,
+      html:not([data-theme]) .content h2,
+      html:not([data-theme]) .content h3,
+      html:not([data-theme]) .content h4 {
+        color: #fff;
+      }
+      html:not([data-theme]) .content code {
+        background: #1a1a2e;
+      }
+      html:not([data-theme]) .content pre {
+        background: #1a1a2e;
+      }
+      html:not([data-theme]) .content blockquote {
+        color: #a1a1aa;
+      }
+      html:not([data-theme]) .content th,
+      html:not([data-theme]) .content td {
+        border-color: #3f3f5a;
+      }
+      html:not([data-theme]) .content th {
+        background: #1a1a2e;
+      }
+    }
+
     @media print {
       body { background: white; color: black; }
       .container { max-width: 100%; }
@@ -596,11 +679,15 @@ export function useTransform(notebookId: string | null = null): UseTransformRetu
           }
 
           // Tab is ready, send content via chrome.tabs.sendMessage
+          // Include theme preference for consistent styling
+          const themePreference = getPreference()
+          const theme: 'light' | 'dark' | null = themePreference === 'system' ? null : themePreference
           void chrome.tabs.sendMessage(tabId, {
             type: 'FULLSCREEN_CONTENT',
             title: result.title,
             content: result.content,
             isInteractive: true,
+            theme,
           })
 
           // Clean up listener
@@ -621,7 +708,10 @@ export function useTransform(notebookId: string | null = null): UseTransformRetu
       const sanitizedContent = DOMPurify.sanitize(renderedContent, {
         USE_PROFILES: { html: true },
       })
-      let fullHtml = generateFullPageHtml(result.title, sanitizedContent)
+      // Include theme preference for consistent styling
+      const themePreference = getPreference()
+      const theme: 'light' | 'dark' | null = themePreference === 'system' ? null : themePreference
+      let fullHtml = generateFullPageHtml(result.title, sanitizedContent, theme)
 
       // Sanitize the entire document
       fullHtml = DOMPurify.sanitize(fullHtml, {


### PR DESCRIPTION
Transform-generated content (both in sidepanel previews and fullscreen views)
now respects the user's theme preference set in FolioLM settings.

Changes:
- sandbox.html: Added [data-theme="dark"] CSS selectors with system fallback
- sandbox.ts: Added SET_THEME message handler to apply theme attribute
- sandbox-renderer.ts: Added setTheme() method for theme communication
- SandboxContent.tsx: Sends theme on render and subscribes to theme changes
- fullscreen-sandbox.ts: Applies theme to generated srcdoc content
- fullscreen-wrapper.ts/html: Forward theme to sandbox and apply styling
- useTransform.ts: Include theme in fullscreen content messages and blob URLs

The theme flows from the extension's preference to sandboxed iframes via
postMessage, with CSS fallback to system preference when set to "system".