### PR TITLE
feat: add About page with contact info and support links

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -720,6 +720,12 @@ Shared modal for tabs, bookmarks, history, and media selection:
 - API key input (hidden for Chrome Built-in)
 - Test connection button
 - Permission toggles (Tabs, Tab Groups, Bookmarks, History)
+- **About** - Link to About page with contact info and support links
+
+### About Page
+- **FolioLM** - Brief product description
+- **Contact** - Email contact (paul@aifoc.us)
+- **Support** - Link to GitHub issues for bug reports and feature requests
 
 ---
 
@@ -800,6 +806,7 @@ src/
 │   │   ├── sources.ts     # Source import functions
 │   │   └── ui.ts         # UI helpers
 │   ├── components/       # Preact UI components
+│   │   └── AboutTab.tsx  # About page with contact and support info
 │   └── styles.css        # Dark theme CSS
 └── types/
     └── index.ts          # TypeScript type definitions

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ src/
 │   ├── components/      # Preact UI components
 │   │   ├── Header.tsx, AddTab.tsx, ChatTab.tsx, etc.
 │   │   ├── TransformConfigPopover.tsx
-│   │   └── DropZone.tsx  # Drag-and-drop overlay for adding sources
+│   │   ├── DropZone.tsx  # Drag-and-drop overlay for adding sources
+│   │   └── AboutTab.tsx  # About page with contact and support info
 │   └── styles.css       # UI styling
 └── types/               # TypeScript interfaces
     └── index.ts         # Notebook, Source, ChatMessage, Credential, ModelConfig, etc.

--- a/src/sidepanel/App.tsx
+++ b/src/sidepanel/App.tsx
@@ -26,6 +26,7 @@ import { ChatTab } from './components/ChatTab'
 import { TransformTab } from './components/TransformTab'
 import { LibraryTab } from './components/LibraryTab'
 import { SettingsTab } from './components/SettingsTab'
+import { AboutTab } from './components/AboutTab'
 import { BottomNav } from './components/BottomNav'
 import { Fab } from './components/Fab'
 import { PickerModal, NotebookDialog, ConfirmDialog, AddNoteDialog, ImagePickerModal } from './components/Modals'
@@ -784,6 +785,8 @@ export function App(props: AppProps) {
           active={activeTab.value === 'settings'}
           onClearAllData={() => void handleClearAllData()}
         />
+
+        <AboutTab active={activeTab.value === 'about'} />
       </main>
 
       <BottomNav activeTab={activeTab.value} onTabClick={handleTabClick} />

--- a/src/sidepanel/components/AboutTab.tsx
+++ b/src/sidepanel/components/AboutTab.tsx
@@ -1,0 +1,57 @@
+import { navigateToTab } from '../store'
+
+interface AboutTabProps {
+  active: boolean
+}
+
+export function AboutTab(props: AboutTabProps) {
+  const { active } = props
+
+  return (
+    <section id="tab-about" className={`tab-content ${active ? 'active' : ''}`}>
+      <h2>About</h2>
+
+      <div className="settings-group">
+        <h3 className="section-title">FolioLM</h3>
+        <p className="setting-hint">
+          Your AI research companion. Collect sources from tabs, bookmarks, and history, then query and transform that content.
+        </p>
+      </div>
+
+      <div className="settings-group">
+        <h3 className="section-title">Contact</h3>
+        <p className="about-contact-item">
+          <svg className="about-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+            <polyline points="22,6 12,13 2,6" />
+          </svg>
+          <a href="mailto:paul@aifoc.us">paul@aifoc.us</a>
+        </p>
+      </div>
+
+      <div className="settings-group">
+        <h3 className="section-title">Support</h3>
+        <p className="about-contact-item">
+          <svg className="about-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+          </svg>
+          <a href="https://github.com/PaulKinlan/NotebookLM-Chrome/issues" target="_blank" rel="noopener noreferrer">
+            Report issues on GitHub
+          </a>
+        </p>
+        <p className="setting-hint">
+          Found a bug or have a feature request? Open an issue on our GitHub repository.
+        </p>
+      </div>
+
+      <div className="settings-group">
+        <button
+          className="btn btn-small btn-outline"
+          onClick={() => navigateToTab('settings')}
+        >
+          Back to Settings
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/src/sidepanel/components/BottomNav.tsx
+++ b/src/sidepanel/components/BottomNav.tsx
@@ -2,7 +2,7 @@
  * BottomNav component - Bottom navigation bar with Add, Chat, and Transform tabs
  */
 
-type TabName = 'add' | 'chat' | 'transform' | 'library' | 'settings'
+import type { TabName } from '../store'
 
 interface BottomNavProps {
   activeTab: TabName

--- a/src/sidepanel/components/SettingsTab.tsx
+++ b/src/sidepanel/components/SettingsTab.tsx
@@ -6,7 +6,7 @@ import { useProviderProfiles } from '../hooks/useProviderProfiles'
 import { useState, useEffect } from 'preact/hooks'
 import { requestPermission, revokePermission } from '../../lib/permissions'
 import { getProviderConfigById } from '../../lib/provider-registry'
-import { showNotification } from '../store'
+import { showNotification, navigateToTab } from '../store'
 import { ProfileForm } from './ProfileForm.tsx'
 import { UsageStatsModal } from './UsageStatsModal.tsx'
 
@@ -405,6 +405,16 @@ export function SettingsTab(props: SettingsTabProps) {
         <h3 className="section-title">Data Management</h3>
         <p className="setting-hint">Clear all notebooks, sources, chat history, and AI profiles. This action cannot be undone.</p>
         <button id="clear-all-data-btn" className="btn btn-danger btn-small" onClick={onClearAllData}>Clear All Data</button>
+      </div>
+
+      <div className="settings-group">
+        <h3 className="section-title">About</h3>
+        <button
+          className="btn btn-small btn-outline"
+          onClick={() => navigateToTab('about')}
+        >
+          About FolioLM
+        </button>
       </div>
 
       <UsageStatsModal

--- a/src/sidepanel/store/signals.ts
+++ b/src/sidepanel/store/signals.ts
@@ -62,10 +62,10 @@ export const hasNotebook = computed(() => currentNotebookId.value !== null)
 // Navigation Signals
 // ============================================================================
 
-export type TabName = 'add' | 'chat' | 'transform' | 'library' | 'settings'
+export type TabName = 'add' | 'chat' | 'transform' | 'library' | 'settings' | 'about'
 
 /** Valid tab names for type checking */
-const validTabs: TabName[] = ['add', 'chat', 'transform', 'library', 'settings']
+const validTabs: TabName[] = ['add', 'chat', 'transform', 'library', 'settings', 'about']
 
 function isValidTab(value: unknown): value is TabName {
   return typeof value === 'string' && validTabs.includes(value as TabName)

--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -4925,3 +4925,30 @@ details.suggested-links-section[open] .suggested-links-chevron {
   color: var(--success);
 }
 
+/* ============================================================================
+   About Tab
+   ============================================================================ */
+
+.about-contact-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.about-contact-item a {
+  color: var(--accent-primary);
+  text-decoration: none;
+}
+
+.about-contact-item a:hover {
+  text-decoration: underline;
+}
+
+.about-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+


### PR DESCRIPTION
Add an About page accessible from Settings that includes:
- FolioLM product description
- Contact email (paul@aifoc.us)
- Link to GitHub issues for bug reports/feature requests

Changes:
- Create AboutTab.tsx component
- Add 'about' to TabName type in signals.ts
- Update App.tsx to render AboutTab
- Add About link in SettingsTab
- Add CSS styles for About page
- Update BottomNav to use shared TabName type
- Update PRD.md and README.md documentation